### PR TITLE
Hidden display and table select style

### DIFF
--- a/src/core/color.rs
+++ b/src/core/color.rs
@@ -1,9 +1,25 @@
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub struct ColorIndexed(pub u8);
+pub struct IconColor {
+    pub normal: u8,
+    pub selected: u8,
+}
+
+impl IconColor {
+    pub const fn new(normal: u8, selected: u8) -> Self {
+        IconColor {
+            normal,
+            selected,
+        }
+    }
+}
 
 #[cfg(feature = "cli")]
-impl From<ColorIndexed> for ratatui::style::Color {
-    fn from(val: ColorIndexed) -> Self {
-        ratatui::style::Color::Indexed(val.0)
+impl IconColor {
+    pub fn normal(self) -> ratatui::style::Color {
+        ratatui::style::Color::Indexed(self.normal)
+    }
+
+    pub fn selected(self) -> ratatui::style::Color {
+        ratatui::style::Color::Indexed(self.selected)
     }
 }

--- a/src/core/heuristic.rs
+++ b/src/core/heuristic.rs
@@ -37,7 +37,8 @@ pub struct Lang {
     /// Short name/abbreviation of the language or heuristic, used when icons are not supported.
     pub short: &'static str,
     /// [ANSI 8-bit color index](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) for the language or heuristic.
-    pub color: ColorIndexed,
+    pub color_normal: ColorIndexed,
+    pub color_selected: ColorIndexed,
 }
 
 impl fmt::Display for Lang {

--- a/src/core/heuristic.rs
+++ b/src/core/heuristic.rs
@@ -1,4 +1,4 @@
-use super::{color::ColorIndexed, MatchingState};
+use super::{color::IconColor, MatchingState};
 use std::fmt;
 
 /// Trait for implementing heuristics to match directories and files for deletion.
@@ -37,8 +37,7 @@ pub struct Lang {
     /// Short name/abbreviation of the language or heuristic, used when icons are not supported.
     pub short: &'static str,
     /// [ANSI 8-bit color index](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) for the language or heuristic.
-    pub color_normal: ColorIndexed,
-    pub color_selected: ColorIndexed,
+    pub color: IconColor,
 }
 
 impl fmt::Display for Lang {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,7 +23,7 @@ mod heuristic;
 pub use heuristic::{CommentedLang, Heuristic, Lang};
 
 mod color;
-pub use color::ColorIndexed;
+pub use color::IconColor;
 
 /// Type for storing files inherited from parent directories.
 /// See [`MatchingState::inherited_files()`].

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -8,7 +8,7 @@ pub const ALL_HEURISTICS: [&dyn Heuristic; 2] = [&rust::INSTANCE, &unity::INSTAN
 
 #[macro_export]
 macro_rules! heuristic {
-    ($name:ident, $icon:literal, $short:literal, $color:expr, $state:ident, $expression:expr) => {
+    ($name:ident, $icon:literal, $short:literal, $color_normal:expr,$color_selected:expr, $state:ident, $expression:expr) => {
         use super::*;
 
         #[derive(Default)]
@@ -22,7 +22,8 @@ macro_rules! heuristic {
                     name: stringify!($name),
                     icon: $icon,
                     short: $short,
-                    color: $color,
+                    color_normal: $color_normal,
+                    color_selected: $color_selected,
                 };
                 &LANG
             }

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -1,4 +1,4 @@
-use crate::core::{ColorIndexed, Heuristic, Lang, MatchingState};
+use crate::core::{Heuristic, IconColor, Lang, MatchingState};
 
 mod rust;
 mod unity;
@@ -8,7 +8,7 @@ pub const ALL_HEURISTICS: [&dyn Heuristic; 2] = [&rust::INSTANCE, &unity::INSTAN
 
 #[macro_export]
 macro_rules! heuristic {
-    ($name:ident, $icon:literal, $short:literal, $color_normal:expr,$color_selected:expr, $state:ident, $expression:expr) => {
+    ($name:ident, $icon:literal, $short:literal, $color:expr, $state:ident, $expression:expr) => {
         use super::*;
 
         #[derive(Default)]
@@ -22,8 +22,7 @@ macro_rules! heuristic {
                     name: stringify!($name),
                     icon: $icon,
                     short: $short,
-                    color_normal: $color_normal,
-                    color_selected: $color_selected,
+                    color: $color,
                 };
                 &LANG
             }

--- a/src/heuristics/rust.rs
+++ b/src/heuristics/rust.rs
@@ -1,6 +1,6 @@
 use crate::heuristic;
 
-heuristic!(Rust, "", "rs", ColorIndexed(202), state, {
+heuristic!(Rust, "", "rs", ColorIndexed(202), ColorIndexed(166), state, {
     if state.has_file("Cargo.toml").is_some() && state.has_directory("target").is_some() {
         state.add_match("target", "Found Cargo.toml and target directory.");
     }

--- a/src/heuristics/rust.rs
+++ b/src/heuristics/rust.rs
@@ -1,6 +1,6 @@
 use crate::heuristic;
 
-heuristic!(Rust, "", "rs", ColorIndexed(202), ColorIndexed(166), state, {
+heuristic!(Rust, "", "rs", IconColor::new(202, 166), state, {
     if state.has_file("Cargo.toml").is_some() && state.has_directory("target").is_some() {
         state.add_match("target", "Found Cargo.toml and target directory.");
     }

--- a/src/heuristics/unity.rs
+++ b/src/heuristics/unity.rs
@@ -17,7 +17,7 @@ const DIRS: [&str; 14] = [
     "recordings",
 ];
 
-heuristic!(Unity, "󰚯", "unity", ColorIndexed(15), state, {
+heuristic!(Unity, "󰚯", "unity", ColorIndexed(15), ColorIndexed(234), state, {
     if state.has_directory("Assets").is_some()
         && state.has_directory("Packages").is_some()
         && state.has_directory("ProjectSettings").is_some()

--- a/src/heuristics/unity.rs
+++ b/src/heuristics/unity.rs
@@ -17,7 +17,7 @@ const DIRS: [&str; 14] = [
     "recordings",
 ];
 
-heuristic!(Unity, "󰚯", "unity", ColorIndexed(15), ColorIndexed(234), state, {
+heuristic!(Unity, "󰚯", "unity", IconColor::new(15, 234), state, {
     if state.has_directory("Assets").is_some()
         && state.has_directory("Packages").is_some()
         && state.has_directory("ProjectSettings").is_some()

--- a/src/ui/model.rs
+++ b/src/ui/model.rs
@@ -95,6 +95,7 @@ impl TableData {
         self.idx += 1;
 
         if let Some(record) = self.data.iter_mut().find(|ele| ele.group_path == path) {
+            record.hidden |= data.hidden();
             record.add_langs_ref(data.languages());
             record.matches.push(ui_data);
         } else {

--- a/src/ui/model.rs
+++ b/src/ui/model.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct MatchGroup {
+    pub hidden: bool,
     pub group_path: PathBuf,
     pub status: MatchDataUIStatus,
     pub languages: Vec<LangDataUI>,
@@ -99,6 +100,7 @@ impl TableData {
         } else {
             self.data.push(
                 MatchGroup {
+                    hidden: data.hidden(),
                     group_path: path,
                     status: MatchDataUIStatus::Found,
                     languages: vec![],

--- a/src/ui/render/popup/info.rs
+++ b/src/ui/render/popup/info.rs
@@ -37,7 +37,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) -> Option<()> {
                 } else {
                     format!("- {} {}", ele.lang.icon, ele.lang.name)
                 },
-                Style::default().fg(ele.lang.color_normal.into()),
+                Style::default().fg(ele.lang.color.normal()),
             )])];
             for comment in &ele.comments {
                 res.push(Line::from(vec![Span::styled(format!("  {}", comment), small_style)]))

--- a/src/ui/render/popup/info.rs
+++ b/src/ui/render/popup/info.rs
@@ -37,7 +37,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) -> Option<()> {
                 } else {
                     format!("- {} {}", ele.lang.icon, ele.lang.name)
                 },
-                Style::default().fg(ele.lang.color.into()),
+                Style::default().fg(ele.lang.color_normal.into()),
             )])];
             for comment in &ele.comments {
                 res.push(Line::from(vec![Span::styled(format!("  {}", comment), small_style)]))

--- a/src/ui/render/popup/info.rs
+++ b/src/ui/render/popup/info.rs
@@ -55,8 +55,18 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) -> Option<()> {
         area,
     );
 
-    let container = Paragraph::new(text);
-    frame.render_widget(container, layout[0]);
+    frame.render_widget(Paragraph::new(text), layout[0]);
+    if match_data.hidden {
+        frame.render_widget(
+            Paragraph::new(if app.args.no_icons {
+                Span::styled("(!)  ", Color::LightYellow)
+            } else {
+                Span::styled("    ", Color::LightYellow)
+            })
+            .alignment(layout::Alignment::Right),
+            layout[0],
+        );
+    }
 
     let widths = [Constraint::Percentage(100), Constraint::Length(10), Constraint::Length(10)];
     let table = Table::new(match_data_to_rows(match_data), widths)

--- a/src/ui/render/table.rs
+++ b/src/ui/render/table.rs
@@ -46,11 +46,7 @@ fn table_data_to_rows(data: &TableData, no_icons: bool, selected: Option<usize>)
                 .map(|e| {
                     Span::styled(
                         if no_icons { format!("{} ", e.lang.short) } else { e.lang.icon.to_owned() },
-                        Style::default().fg(if is_selected {
-                            e.lang.color_selected.into()
-                        } else {
-                            e.lang.color_normal.into()
-                        }),
+                        Style::default().fg(if is_selected { e.lang.color.selected() } else { e.lang.color.normal() }),
                     )
                 })
                 .collect();

--- a/src/ui/render/table.rs
+++ b/src/ui/render/table.rs
@@ -70,7 +70,7 @@ fn table_data_to_rows(data: &TableData, no_icons: bool, selected: Option<usize>)
             Row::new(vec![
                 Cell::new(Line::from(icons)),
                 Cell::new(Line::from(line)),
-                Cell::new(Line::from(if !ele.hidden {
+                Cell::new(Line::from(if ele.hidden {
                     if no_icons {
                         Span::styled("(!)", warn_color)
                     } else {

--- a/src/ui/render/table.rs
+++ b/src/ui/render/table.rs
@@ -20,30 +20,37 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
         Constraint::Length(8),
     ];
     let table_data = app.table.clone();
-    let table = Table::new(table_data_to_rows(&table_data, app.args.no_icons), widths)
+    let table = Table::new(table_data_to_rows(&table_data, app.args.no_icons, app.table.state.selected()), widths)
         .column_spacing(1)
         .header(
             Row::new(vec!["", "Path", "", "LastMod", "Size"])
                 .style(Style::default().bg(Color::Cyan).add_modifier(Modifier::BOLD)),
         )
-        .block(Block::bordered().border_type(BorderType::Rounded))
-        .highlight_style(Style::default().reversed())
-        .highlight_symbol(" ");
+        .block(Block::bordered().border_type(BorderType::Rounded));
 
     frame.render_stateful_widget(table, area, &mut app.table.state);
 }
 
-fn table_data_to_rows(data: &TableData, no_icons: bool) -> Vec<Row> {
+fn table_data_to_rows(data: &TableData, no_icons: bool, selected: Option<usize>) -> Vec<Row> {
     data.data
         .iter()
-        .map(|ele| {
+        .enumerate()
+        .map(|(idx, ele)| {
+            let is_selected = selected.and_then(|s| if s == idx { Some(()) } else { None }).is_some();
+            let fg = if is_selected { Color::Black } else { Color::White };
+            let bg = if is_selected { Color::White } else { Color::Reset };
+
             let icons: Vec<_> = ele
                 .languages
                 .iter()
                 .map(|e| {
                     Span::styled(
                         if no_icons { format!("{} ", e.lang.short) } else { e.lang.icon.to_owned() },
-                        Style::default().fg(e.lang.color.into()),
+                        Style::default().fg(if is_selected {
+                            e.lang.color_selected.into()
+                        } else {
+                            e.lang.color_normal.into()
+                        }),
                     )
                 })
                 .collect();
@@ -53,31 +60,35 @@ fn table_data_to_rows(data: &TableData, no_icons: bool) -> Vec<Row> {
                     vec![
                         Span::styled("[del]", Style::default().fg(Color::Red)),
                         Span::from(" "),
-                        Span::from(ele.group_path.display().to_string()),
+                        Span::styled(ele.group_path.display().to_string(), fg),
                     ]
                 },
-                MatchDataUIStatus::Found => vec![Span::from(ele.group_path.display().to_string())],
+                MatchDataUIStatus::Found => vec![Span::styled(ele.group_path.display().to_string(), fg)],
             };
 
+            let warn_color = if is_selected { Color::Yellow } else { Color::LightYellow };
             Row::new(vec![
                 Cell::new(Line::from(icons)),
                 Cell::new(Line::from(line)),
                 Cell::new(Line::from(if !ele.hidden {
                     if no_icons {
-                        Span::styled("(!)", Color::LightYellow)
+                        Span::styled("(!)", warn_color)
                     } else {
-                        Span::styled("  ", Color::LightYellow)
+                        Span::styled("  ", warn_color)
                     }
                 } else {
                     Span::from("")
                 })),
-                Cell::new(if let Some(s) = &ele.stats().last_mod_days() {
-                    format!("{}d", s)
-                } else {
-                    "---".to_owned()
-                }),
-                Cell::new(if let Some(s) = &ele.stats().size { format!("{}", s) } else { "---".to_owned() }),
+                Cell::new(Span::styled(
+                    if let Some(s) = &ele.stats().last_mod_days() { format!("{}d", s) } else { "---".to_owned() },
+                    fg,
+                )),
+                Cell::new(Span::styled(
+                    if let Some(s) = &ele.stats().size { format!("{}", s) } else { "---".to_owned() },
+                    fg,
+                )),
             ])
+            .bg(bg)
         })
         .collect()
 }

--- a/src/ui/render/table.rs
+++ b/src/ui/render/table.rs
@@ -12,12 +12,18 @@ use crate::ui::{
 };
 
 pub fn render(app: &mut App, frame: &mut Frame, area: Rect) {
-    let widths = [Constraint::Length(6), Constraint::Percentage(100), Constraint::Length(10), Constraint::Length(10)];
+    let widths = [
+        Constraint::Length(6),
+        Constraint::Percentage(100),
+        Constraint::Length(3),
+        Constraint::Length(8),
+        Constraint::Length(8),
+    ];
     let table_data = app.table.clone();
     let table = Table::new(table_data_to_rows(&table_data, app.args.no_icons), widths)
         .column_spacing(1)
         .header(
-            Row::new(vec!["", "Path", "LastMod", "Size"])
+            Row::new(vec!["", "Path", "", "LastMod", "Size"])
                 .style(Style::default().bg(Color::Cyan).add_modifier(Modifier::BOLD)),
         )
         .block(Block::bordered().border_type(BorderType::Rounded))
@@ -56,6 +62,15 @@ fn table_data_to_rows(data: &TableData, no_icons: bool) -> Vec<Row> {
             Row::new(vec![
                 Cell::new(Line::from(icons)),
                 Cell::new(Line::from(line)),
+                Cell::new(Line::from(if !ele.hidden {
+                    if no_icons {
+                        Span::styled("(!)", Color::LightYellow)
+                    } else {
+                        Span::styled("  ", Color::LightYellow)
+                    }
+                } else {
+                    Span::from("")
+                })),
                 Cell::new(if let Some(s) = &ele.stats().last_mod_days() {
                     format!("{}d", s)
                 } else {


### PR DESCRIPTION
This pull request includes several changes to improve the hidden display and table select style. The `Lang` struct now has separate color properties for normal and selected states. The `heuristic!` macro has been updated to include these new color properties. The `render` function now uses the `color_normal` property to style the language icons. Additionally, the `MatchGroup` struct now includes a `hidden` property, and the `render` function displays a warning icon for hidden matches. The `table_data_to_rows` function has been updated to style the table cells based on the selected state. Overall, these changes enhance the visibility and style of hidden matches and improve the table select style.