### PR TITLE
Heuristics: gitignore, hidden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +317,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +350,22 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.7",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "instability"
@@ -537,6 +576,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "directories",
+ "ignore",
  "jwalk",
  "ratatui",
  "size",
@@ -717,10 +757,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -977,6 +1046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1076,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing-error = { version = "0.2.0", optional = true }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }
 directories = { version = "5.0.1", optional = true }
+ignore = "0.4.22"
 
 [features]
 cli = ["dep:clap", "dep:ratatui", "dep:throbber-widgets-tui", "dep:unicode-segmentation", "dep:tracing-error", "dep:tracing-subscriber", "dep:directories"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,7 @@ pub struct Args {
     /// Do not ask for confirmation when deleting directories
     #[arg(short = 'y')]
     pub delete_instantly: bool,
-    /// Show dangerous paths
+    /// Show dangerous paths, e.g. hidden files and directories used by other apps
     #[arg(long)]
     pub dangerous: bool,
 }

--- a/src/core/heuristic.rs
+++ b/src/core/heuristic.rs
@@ -51,7 +51,7 @@ impl fmt::Display for Lang {
 pub struct CommentedLang {
     /// Language this struct is based on.
     pub lang: &'static Lang,
-    /// Comment for this instance of [`LangData`], present only when querying specific match information.
+    /// Additional comment.
     pub comment: String,
 }
 

--- a/src/heuristics/git.rs
+++ b/src/heuristics/git.rs
@@ -11,11 +11,11 @@ enum GitMatchWeight {
 }
 
 impl GitMatchWeight {
-    const fn comment(&self) -> &'static str {
+    fn comment(&self, file_name: &str) -> String {
         match self {
-            GitMatchWeight::NotMatched => "File was not included in any .gitignore files that were found.",
-            GitMatchWeight::Ignored => "File was included in one of .gitignore files.",
-            GitMatchWeight::Whitelisted => "File was explicitly whitelisted in one of .gitignore files.",
+            GitMatchWeight::NotMatched => format!("{file_name} was not included in any .gitignore files that were found."),
+            GitMatchWeight::Ignored => format!("{file_name} was included in one of .gitignore files."),
+            GitMatchWeight::Whitelisted => format!("{file_name} was explicitly whitelisted in one of .gitignore files."),
         }
     }
 }
@@ -61,6 +61,7 @@ heuristic!(Git, "", "git", IconColor::new(202, 166), state, {
         .collect();
     let group = state.inherited_files()[0].clone();
     for (name, weight) in matches {
-        state.add_match(&name, weight.comment()).weight(weight as i32).custom_group(group.clone());
+        let comment = weight.comment(&name.to_string_lossy());
+        state.add_match(&name, &comment).weight(weight as i32).custom_group(group.clone());
     }
 });

--- a/src/heuristics/git.rs
+++ b/src/heuristics/git.rs
@@ -5,7 +5,7 @@ enum GitMatchWeight {
     /// File was not matched, maybe the user wants to leave it as is?
     NotMatched = -1_000,
     /// File was ignored, so it probably can be removed.
-    Ignored = 500,
+    Ignored = 0, // TODO: Change after some kind of settings implementation
     /// File was explicitly whitelisted, we are not touching it.
     Whitelisted = -10_000,
 }

--- a/src/heuristics/git.rs
+++ b/src/heuristics/git.rs
@@ -30,7 +30,7 @@ impl<T> From<Match<T>> for GitMatchWeight {
     }
 }
 
-heuristic!(Git, "󰊢", "git", ColorIndexed(202), state, {
+heuristic!(Git, "", "git", ColorIndexed(202), state, {
     if let Some(gitignore) = state.has_file(".gitignore") {
         state.inherited_files().push(gitignore);
     }

--- a/src/heuristics/git.rs
+++ b/src/heuristics/git.rs
@@ -1,0 +1,56 @@
+use crate::heuristic;
+use ignore::{gitignore::Gitignore, Match};
+
+enum GitMatchWeight {
+    /// File was not matched, maybe the user wants to leave it as is?
+    NotMatched = -1_000,
+    /// File was ignored, so it probably can be removed.
+    Ignored = 500,
+    /// File was explicitly whitelisted, we are not touching it.
+    Whitelisted = -10_000,
+}
+
+impl GitMatchWeight {
+    const fn comment(&self) -> &'static str {
+        match self {
+            GitMatchWeight::NotMatched => "File was not included in any .gitignore files that were found.",
+            GitMatchWeight::Ignored => "File was included in one of .gitignore files.",
+            GitMatchWeight::Whitelisted => "File was explicitly whitelisted in one of .gitignore files.",
+        }
+    }
+}
+
+impl<T> From<Match<T>> for GitMatchWeight {
+    fn from(value: Match<T>) -> Self {
+        match value {
+            Match::None => GitMatchWeight::NotMatched,
+            Match::Ignore(_) => GitMatchWeight::Ignored,
+            Match::Whitelist(_) => GitMatchWeight::Whitelisted,
+        }
+    }
+}
+
+heuristic!(Git, "󰊢", "git", ColorIndexed(202), state, {
+    if let Some(gitignore) = state.has_file(".gitignore") {
+        state.inherited_files().push(gitignore);
+    }
+
+    if state.inherited_files().is_empty() {
+        return;
+    }
+
+    let matchers: Vec<_> = state.inherited_files().iter().rev().map(|ignore| Gitignore::new(ignore).0).collect();
+    let matches: Vec<_> = state
+        .get_all_contents()
+        .filter(|(path, _)| path.file_name().is_some())
+        .map(|(path, ptype)| {
+            let final_verdict =
+                matchers.iter().map(|m| m.matched(&path, ptype.is_dir())).fold(Match::None, |a, b| a.or(b));
+            let weight: GitMatchWeight = final_verdict.into();
+            (path.file_name().unwrap().to_owned(), weight)
+        })
+        .collect();
+    for (name, weight) in matches {
+        state.add_match(&name, weight.comment()).weight(weight as i32);
+    }
+});

--- a/src/heuristics/hidden.rs
+++ b/src/heuristics/hidden.rs
@@ -1,0 +1,13 @@
+use crate::heuristic;
+use std::ffi::OsStr;
+
+heuristic!(Hidden, "󰘓", ".", ColorIndexed(7), state, {
+    let to_hide: Vec<_> = state
+        .get_all_contents()
+        .filter_map(|v| v.0.file_name().map(OsStr::to_owned))
+        .filter(|name| name.to_str().is_some_and(|s| s.starts_with('.')))
+        .collect();
+    for path in to_hide {
+        state.add_match(&path, "Path starts with a dot.").weight(0).hidden();
+    }
+});

--- a/src/heuristics/hidden.rs
+++ b/src/heuristics/hidden.rs
@@ -8,6 +8,6 @@ heuristic!(Hidden, "󰘓", ".", IconColor::new(7, 8), state, {
         .filter(|name| name.to_str().is_some_and(|s| s.starts_with('.')))
         .collect();
     for path in to_hide {
-        state.add_match(&path, "Path starts with a dot.").weight(0).hidden();
+        state.add_match(&path, &format!("{} starts with a dot.", path.to_string_lossy())).weight(0).hidden();
     }
 });

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -1,14 +1,15 @@
 use crate::core::{ColorIndexed, Heuristic, Lang, MatchingState};
 
+mod git;
+mod hidden;
 mod rust;
 mod unity;
-mod git;
 
 /// A list of all heuristics implemented by default in this crate.
-pub const ALL_HEURISTICS: [&dyn Heuristic; 3] = [&rust::INSTANCE, &unity::INSTANCE, &git::INSTANCE];
+pub const ALL_HEURISTICS: [&dyn Heuristic; 4] = [&hidden::INSTANCE, &rust::INSTANCE, &unity::INSTANCE, &git::INSTANCE];
 
 /// Simplified heuristic declaration.
-/// 
+///
 /// Parameters in order:
 /// - `name` - heuristic name, also used as a generated struct indentifier,
 /// - `icon` - Nerd Font icon (see [`Lang::icon`]),

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -2,10 +2,20 @@ use crate::core::{ColorIndexed, Heuristic, Lang, MatchingState};
 
 mod rust;
 mod unity;
+mod git;
 
 /// A list of all heuristics implemented by default in this crate.
-pub const ALL_HEURISTICS: [&dyn Heuristic; 2] = [&rust::INSTANCE, &unity::INSTANCE];
+pub const ALL_HEURISTICS: [&dyn Heuristic; 3] = [&rust::INSTANCE, &unity::INSTANCE, &git::INSTANCE];
 
+/// Simplified heuristic declaration.
+/// 
+/// Parameters in order:
+/// - `name` - heuristic name, also used as a generated struct indentifier,
+/// - `icon` - Nerd Font icon (see [`Lang::icon`]),
+/// - `short` - heuristic name abbreviation (see [`Lang::short`]),
+/// - `color` - [`ColorIndexed`] instance,
+/// - `state` - parameter name for [`Heuristic::check_for_matches()`],
+/// - `expression` - heuristic body with state in scope.
 #[macro_export]
 macro_rules! heuristic {
     ($name:ident, $icon:literal, $short:literal, $color:expr, $state:ident, $expression:expr) => {

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -14,7 +14,7 @@ pub const ALL_HEURISTICS: [&dyn Heuristic; 4] = [&hidden::INSTANCE, &rust::INSTA
 /// - `name` - heuristic name, also used as a generated struct indentifier,
 /// - `icon` - Nerd Font icon (see [`Lang::icon`]),
 /// - `short` - heuristic name abbreviation (see [`Lang::short`]),
-/// - `color` - [`ColorIndexed`] instance,
+/// - `color` - [`IconColor`] instance,
 /// - `state` - parameter name for [`Heuristic::check_for_matches()`],
 /// - `expression` - heuristic body with state in scope.
 #[macro_export]

--- a/src/heuristics/rust.rs
+++ b/src/heuristics/rust.rs
@@ -1,6 +1,6 @@
 use crate::heuristic;
 
-heuristic!(Rust, "", "rs", ColorIndexed(202), state, {
+heuristic!(Rust, "", "rs", ColorIndexed(166), state, {
     if state.has_file("Cargo.toml").is_some() && state.has_directory("target").is_some() {
         state.add_match("target", "Found Cargo.toml and target directory.");
     }

--- a/src/heuristics/unity.rs
+++ b/src/heuristics/unity.rs
@@ -26,7 +26,7 @@ heuristic!(Unity, "󰚯", "unity", IconColor::new(15, 234), state, {
             if state.has_directory(dir).is_some() {
                 state.add_match(
                     dir,
-                    &format!("Unity project: Found Assets, Packages, ProjectSettings and {dir} directory."),
+                    &format!("Found Assets, Packages, ProjectSettings and {dir} directory."),
                 );
             }
         }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -14,9 +14,12 @@ pub fn run(args: super::args::Args) {
     let collector = move || {
         let mut collected = vec![];
         while let Ok(data) = receiver.recv() {
-            println!("{}", data.path.display());
+            if !args.dangerous && data.hidden() {
+                continue;
+            }
+            println!("{}{}", if data.hidden() { "(Dangerous!) " } else { "" }, data.path.display());
             for language in data.languages() {
-                println!("-> {}", language);
+                println!("\t-> {}", language);
             }
             collected.push(data.path);
         }
@@ -39,7 +42,7 @@ pub fn run(args: super::args::Args) {
     }
 
     let confirmed = args.delete_instantly || {
-        let form = if results.len() == 1 { "directory" } else { "directories" };
+        let form = if results.len() == 1 { "path" } else { "paths" };
         println!("Do you want to permanently delete the {} {} listed above?", results.len(), form);
         print!("WARNING: this action is irreversible! [y/N] ");
         let _ = stdout().flush();

--- a/src/ui/model.rs
+++ b/src/ui/model.rs
@@ -63,7 +63,7 @@ pub enum MatchDataUIStatus {
     Selected,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TableData {
     pub idx: usize,
     pub state: TableState,
@@ -71,20 +71,9 @@ pub struct TableData {
     cleanable_space: Size,
 }
 
-impl Default for TableData {
-    fn default() -> Self {
-        Self {
-            idx: 0,
-            state: Default::default(),
-            data: Default::default(),
-            cleanable_space: Size::from_bytes(0),
-        }
-    }
-}
-
 impl TableData {
     pub fn add_match(&mut self, data: MatchData) {
-        let path = data.group.clone();
+        let path = data.group().to_owned();
 
         let ui_data = MatchDataUI {
             idx: self.idx,


### PR DESCRIPTION
This branch adds `Git` heuristic, which assigns different weights to all files based on found `.gitignore`s. It also adds `Hidden` semi-heuristic, which hides paths starting with a dot.